### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run_script.yml
+++ b/.github/workflows/run_script.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '0 10 * * *'
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   run_script:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/aegisfleet/hugging-face-trending-to-bluesky/security/code-scanning/2](https://github.com/aegisfleet/hugging-face-trending-to-bluesky/security/code-scanning/2)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Based on the workflow's steps, the following permissions are needed:
- `contents: read` for checking out the repository.
- `actions: read` for downloading and uploading artifacts.

The `permissions` block should be added at the root level, applying to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
